### PR TITLE
Ensure decoder does not drop frames

### DIFF
--- a/src/libvx.c
+++ b/src/libvx.c
@@ -887,7 +887,7 @@ static vx_error vx_decode_frame(vx_video* me, static AVFrame* out_frame_buffer[5
 	vx_read_frame(me->fmt_ctx, packet, me->video_stream);
 
 	// Only attempt to deocde packets from the two streams that have been selected
-	if (packet->stream_index != me->video_stream && packet->stream_index != me->audio_stream)
+	if (packet->data && packet->stream_index != me->video_stream && packet->stream_index != me->audio_stream)
 	{
 		ret = VX_ERR_SUCCESS;
 		goto cleanup;

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -457,6 +457,11 @@ static int hw_decoder_init(vx_video* me, AVCodecContext* ctx, const enum AVHWDev
 
 	ctx->hw_device_ctx = av_buffer_ref(me->hw_device_ctx);
 
+	// Decoder does not assign sufficient pool size for mpeg2
+	if (ctx->codec_id == AV_CODEC_ID_MPEG2VIDEO) {
+		ctx->extra_hw_frames = 16;
+	}
+
 	return err;
 }
 
@@ -485,6 +490,7 @@ static bool find_stream_and_open_codec(vx_video* me, enum AVMediaType type,
 		*out_error = VX_ERR_ALLOCATE;
 		return false;
 	}
+
 	avcodec_parameters_to_context(codec_ctx, me->fmt_ctx->streams[*out_stream]->codecpar);
 	*out_codec_ctx = codec_ctx;
 

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -900,7 +900,7 @@ static vx_error vx_decode_frame(vx_video* me, static AVFrame* out_frame_buffer[5
 	}
 
 	*out_stream_idx = packet->stream_index;
-	codec_ctx = packet->stream_index == me->video_stream
+	codec_ctx = packet->data == NULL || packet->stream_index == me->video_stream
 		? me->video_codec_ctx
 		: me->audio_codec_ctx;
 

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -458,7 +458,7 @@ static int hw_decoder_init(vx_video* me, AVCodecContext* ctx, const enum AVHWDev
 	ctx->hw_device_ctx = av_buffer_ref(me->hw_device_ctx);
 
 	// Decoder does not assign sufficient pool size for mpeg2
-	if (ctx->codec_id == AV_CODEC_ID_MPEG2VIDEO) {
+	if (ctx->codec_id == AV_CODEC_ID_MPEG2VIDEO && ctx->extra_hw_frames < 16) {
 		ctx->extra_hw_frames = 16;
 	}
 


### PR DESCRIPTION
- Flush decoder after processing
- Ensure hardware pool size is sufficient for mpeg2 videos