### PR TITLE
Fix frame buffer overrun

### DIFF
--- a/src/libvx.c
+++ b/src/libvx.c
@@ -937,16 +937,10 @@ static vx_error vx_decode_frame(vx_video* me, static AVFrame* out_frame_buffer[5
 		goto cleanup;
 	}
 
-	if (packet->data) {
-		*out_stream_idx = packet->stream_index;
-		codec_ctx = packet->stream_index == me->video_stream
-			? me->video_codec_ctx
-			: me->audio_codec_ctx;
-	}
-	else {
-		*out_stream_idx = me->video_stream;
-		codec_ctx = me->video_codec_ctx;
-	}
+	*out_stream_idx = packet->stream_index;
+	codec_ctx = packet->stream_index == me->video_stream
+		? me->video_codec_ctx
+		: me->audio_codec_ctx;
 
 	// The decoder may still hold a couple of cached frames, so even if the end of the file has been
 	// reached and no packet is returned, it still needs to be sent in order to flush the decoder

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -936,7 +936,6 @@ static vx_error vx_decode_frame(vx_video* me, static AVFrame* out_frame_buffer[5
 		goto cleanup;
 	}
 
-
 	// If the packet is empty then the end of the video has been reached. Howevert the decoder may still hold a couple
 	// of cached frames and needs to be flushed. This is done by sending an empty packet
 	if (!packet->data) {
@@ -987,7 +986,13 @@ static vx_error vx_decode_frame(vx_video* me, static AVFrame* out_frame_buffer[5
 			goto cleanup;
 		}
 		else {
-			out_frame_buffer[frame_count++] = frame;
+			if (frame_count < 50) {
+				out_frame_buffer[frame_count++] = frame;
+			}
+			else {
+				// Dump the frame and the rest of the packet data to prevent buffer overrun
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix an issue where audio frames flushed from the decoder could be incorrectly returned as video frames. Since the decoder may hold many audio frames and was assumed to only return a single video frame, this could cause a buffer overrun.