### PR TITLE
Rewrite audio handling and unify with video frame queue

### DIFF
--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1052,15 +1052,12 @@ void vx_frame_destroy(vx_frame* me)
 	free(me);
 }
 
-void* vx_frame_get_buffer(vx_frame* frame)
-{
-	return frame->buffer;
-}
-
-int vx_frame_get_buffer_size(const vx_frame* frame)
+void* vx_frame_get_video_buffer(vx_frame* frame, int* out_buffer_size)
 {
 	int av_pixfmt = vx_to_av_pix_fmt(frame->pix_fmt);
-	return av_image_get_buffer_size(av_pixfmt, frame->width, frame->height, 1) + FRAME_BUFFER_PADDING;
+	*out_buffer_size = av_image_get_buffer_size(av_pixfmt, frame->width, frame->height, 1) + FRAME_BUFFER_PADDING;
+
+	return frame->buffer;
 }
 
 void* vx_frame_get_audio_buffer(const vx_frame* frame, int* out_sample_count)

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -286,7 +286,7 @@ static vx_error vx_insert_filter(AVFilterContext** last_filter, int* pad_index, 
 static vx_error vx_initialize_audio_filter(AVFilterContext** last_filter, const int* pad_index)
 {
 	int result = VX_ERR_UNKNOWN;
-	char transform_args[] = "metadata=1:reset=1:measure_overall=Peak_level+RMS_level+RMS_peak";
+	char transform_args[] = "metadata=1:reset=1:measure_overall=Peak_level+RMS_level+RMS_peak:measure_perchannel=0";
 
 	if ((result = vx_insert_filter(last_filter, pad_index, "astats", NULL, transform_args)) != VX_ERR_SUCCESS)
 		return result;

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -48,9 +48,9 @@ struct vx_rectangle
 
 struct vx_audio_info
 {
-	double max_level;
-	double rms_level;
 	double peak_level;
+	double rms_level;
+	double rms_peak;
 };
 
 struct vx_scene_info
@@ -286,8 +286,7 @@ static vx_error vx_insert_filter(AVFilterContext** last_filter, int* pad_index, 
 static vx_error vx_initialize_audio_filter(AVFilterContext** last_filter, const int* pad_index)
 {
 	int result = VX_ERR_UNKNOWN;
-	//char transform_args[] = "measure_perchannel=none:metadata=Max level";
-	char transform_args[] = "metadata=1:reset=1";
+	char transform_args[] = "metadata=1:reset=1:measure_overall=Peak_level+RMS_level+RMS_peak";
 
 	if ((result = vx_insert_filter(last_filter, pad_index, "astats", NULL, transform_args)) != VX_ERR_SUCCESS)
 		return result;
@@ -1200,9 +1199,9 @@ static vx_error vx_frame_properties_from_metadata(vx_frame* frame, const AVFrame
 	vx_scene_info scene_info = { 0, 0, false };
 
 	// TODO: 0 is the maximum db level, so a different default should be returned
-	audio_info.max_level = vx_frame_metadata_as_double(av_frame, "lavfi.astats.Overall.Max_level");
-	audio_info.rms_level = vx_frame_metadata_as_double(av_frame, "lavfi.astats.Overall.RMS_level");
 	audio_info.peak_level = vx_frame_metadata_as_double(av_frame, "lavfi.astats.Overall.Peak_level");
+	audio_info.rms_level = vx_frame_metadata_as_double(av_frame, "lavfi.astats.Overall.RMS_level");
+	audio_info.rms_peak = vx_frame_metadata_as_double(av_frame, "lavfi.astats.Overall.RMS_peak");
 
 	scene_info.difference = vx_frame_metadata_as_double(av_frame, "lavfi.scd.mafd");
 	scene_info.scene_score = vx_frame_metadata_as_double(av_frame, "lavfi.scd.score");

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1340,12 +1340,17 @@ vx_error vx_frame_step_internal(vx_video* me, vx_frame_info* frame_info)
 	if (me->frame_queue_count > 0) {
 		frame = vx_get_first_queue_item(me);
 
+		int stream_type = frame->pict_type != AV_PICTURE_TYPE_NONE
+			? me->video_stream
+			: me->audio_stream;
+
 		// Have to return the calculated frame dimensions here. The dimensions are
 		// needed before they are actually known, i.e. after filtering
 		frame_info->width = frame->width;
 		frame_info->height = frame->height;
 		vx_get_adjusted_frame_dimensions(me, &frame_info->width, &frame_info->height);
-		frame_info->timestamp = vx_estimate_timestamp(me, me->video_stream, frame->best_effort_timestamp);
+		// TODO: Handle duplicate audio timestamps
+		frame_info->timestamp = vx_estimate_timestamp(me, stream_type, frame->best_effort_timestamp);
 		frame_info->flags = frame->pict_type != AV_PICTURE_TYPE_NONE ? VX_FF_HAS_IMAGE : 0;
 		frame_info->flags |= frame->nb_samples > 0 ? VX_FF_HAS_AUDIO : 0;
 		frame_info->flags |= frame->pict_type == AV_PICTURE_TYPE_I ? VX_FF_KEYFRAME : 0;

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -11,7 +11,7 @@
 #include <libavfilter/buffersrc.h>
 #include <libavformat/avformat.h>
 #include <libavutil/channel_layout.h>
-#include "libavutil/display.h"
+#include <libavutil/display.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/mathematics.h>
 #include <libavutil/pixfmt.h>
@@ -731,7 +731,7 @@ vx_error vx_open(vx_video** video, const char* filename, const vx_video_options 
 
 	if (me->audio_codec_ctx) {
 		vx_audio_params params = me->options.audio_params;
-		if (me->options.audio_params.channels > 0) {
+		if (params.channels > 0) {
 			if ((error = vx_set_audio_params(me, params.sample_rate, params.channels, params.sample_format)) != VX_ERR_SUCCESS) {
 				goto cleanup;
 			}

--- a/src/libvx.h
+++ b/src/libvx.h
@@ -95,7 +95,6 @@ VX_DECLSPEC int VX_CDECL vx_get_audio_channels(const vx_video* video);
 
 VX_DECLSPEC long long VX_CDECL vx_get_file_position(const vx_video* video);
 VX_DECLSPEC long long VX_CDECL vx_get_file_size(const vx_video* video);
-VX_DECLSPEC double VX_CDECL vx_timestamp_to_seconds(const vx_video* video, const long long ts);
 
 // Note that you need to re-open the file (create a new vx_video instance) after counting frames.
 VX_DECLSPEC vx_error VX_CDECL vx_count_frames(vx_video* me, int* out_num_frames);

--- a/src/libvx.h
+++ b/src/libvx.h
@@ -11,6 +11,7 @@ extern "C" {
 typedef struct vx_video vx_video;
 typedef struct vx_audio_params vx_audio_params;
 typedef struct vx_video_options vx_video_options;
+typedef struct vx_audio_info vx_audio_info;
 typedef struct vx_scene_info vx_scene_info;
 typedef struct vx_frame vx_frame;
 typedef struct vx_frame_info vx_frame_info;
@@ -113,6 +114,7 @@ VX_DECLSPEC vx_error VX_CDECL vx_frame_step(vx_video* video, vx_frame_info* fram
 VX_DECLSPEC vx_error VX_CDECL vx_frame_transfer_data(const vx_video* video, vx_frame* frame);
 VX_DECLSPEC void* VX_CDECL vx_frame_get_buffer(vx_frame* frame);
 VX_DECLSPEC int VX_CDECL vx_frame_get_buffer_size(const vx_frame* frame);
+VX_DECLSPEC vx_audio_info VX_CDECL vx_frame_get_audio_info(const vx_frame* frame);
 VX_DECLSPEC vx_scene_info VX_CDECL vx_frame_get_scene_info(const vx_frame* frame);
 
 #ifdef __cplusplus

--- a/src/libvx.h
+++ b/src/libvx.h
@@ -93,8 +93,6 @@ VX_DECLSPEC int VX_CDECL vx_get_audio_present(const vx_video* video);
 VX_DECLSPEC int VX_CDECL vx_get_audio_sample_rate(const vx_video* video);
 VX_DECLSPEC int VX_CDECL vx_get_audio_channels(const vx_video* video);
 
-VX_DECLSPEC vx_error VX_CDECL vx_set_audio_params(vx_video* me, int sample_rate, int channels, vx_sample_fmt format);
-
 VX_DECLSPEC long long VX_CDECL vx_get_file_position(const vx_video* video);
 VX_DECLSPEC long long VX_CDECL vx_get_file_size(const vx_video* video);
 VX_DECLSPEC double VX_CDECL vx_timestamp_to_seconds(const vx_video* video, const long long ts);
@@ -107,12 +105,13 @@ VX_DECLSPEC vx_error VX_CDECL vx_get_frame_rate(const vx_video* video, float* ou
 VX_DECLSPEC vx_error VX_CDECL vx_get_duration(const vx_video* video, float* out_duration);
 VX_DECLSPEC bool VX_CDECL vx_get_hw_context_present(const vx_video* video);
 
-VX_DECLSPEC vx_frame* VX_CDECL vx_frame_create(int width, int height, vx_pix_fmt pix_fmt);
+VX_DECLSPEC vx_frame* VX_CDECL vx_frame_create(const vx_video* video, int width, int height, vx_pix_fmt pix_fmt);
 VX_DECLSPEC void VX_CDECL vx_frame_destroy(vx_frame* frame);
 
 VX_DECLSPEC vx_error VX_CDECL vx_frame_step(vx_video* video, vx_frame_info* frame_info);
 VX_DECLSPEC vx_error VX_CDECL vx_frame_transfer_data(const vx_video* video, vx_frame* frame);
 VX_DECLSPEC void* VX_CDECL vx_frame_get_buffer(vx_frame* frame);
+VX_DECLSPEC void* VX_CDECL vx_frame_get_audio_buffer(vx_frame* frame);
 VX_DECLSPEC int VX_CDECL vx_frame_get_buffer_size(const vx_frame* frame);
 VX_DECLSPEC vx_audio_info VX_CDECL vx_frame_get_audio_info(const vx_frame* frame);
 VX_DECLSPEC vx_scene_info VX_CDECL vx_frame_get_scene_info(const vx_frame* frame);

--- a/src/libvx.h
+++ b/src/libvx.h
@@ -110,9 +110,8 @@ VX_DECLSPEC void VX_CDECL vx_frame_destroy(vx_frame* frame);
 
 VX_DECLSPEC vx_error VX_CDECL vx_frame_step(vx_video* video, vx_frame_info* frame_info);
 VX_DECLSPEC vx_error VX_CDECL vx_frame_transfer_data(const vx_video* video, vx_frame* frame);
-VX_DECLSPEC void* VX_CDECL vx_frame_get_buffer(vx_frame* frame);
-VX_DECLSPEC void* VX_CDECL vx_frame_get_audio_buffer(vx_frame* frame);
-VX_DECLSPEC int VX_CDECL vx_frame_get_buffer_size(const vx_frame* frame);
+VX_DECLSPEC void* VX_CDECL vx_frame_get_video_buffer(vx_frame* frame, int* out_buffer_size);
+VX_DECLSPEC void* VX_CDECL vx_frame_get_audio_buffer(vx_frame* frame, int* out_sample_count);
 VX_DECLSPEC vx_audio_info VX_CDECL vx_frame_get_audio_info(const vx_frame* frame);
 VX_DECLSPEC vx_scene_info VX_CDECL vx_frame_get_scene_info(const vx_frame* frame);
 

--- a/src/libvx.h
+++ b/src/libvx.h
@@ -9,6 +9,7 @@ extern "C" {
 #define VX_CDECL __cdecl
 
 typedef struct vx_video vx_video;
+typedef struct vx_audio_params vx_audio_params;
 typedef struct vx_video_options vx_video_options;
 typedef struct vx_scene_info vx_scene_info;
 typedef struct vx_frame vx_frame;
@@ -16,65 +17,65 @@ typedef struct vx_frame_info vx_frame_info;
 typedef struct vx_rectangle vx_rectangle;
 
 typedef enum {
-	VX_LOG_NONE    = 0,
-	VX_LOG_FATAL   = 1,
-	VX_LOG_ERROR   = 2,
-	VX_LOG_WARNING = 3,
-	VX_LOG_INFO    = 4,
-	VX_LOG_DEBUG   = 5
+	VX_LOG_NONE				= 0,
+	VX_LOG_FATAL			= 1,
+	VX_LOG_ERROR			= 2,
+	VX_LOG_WARNING			= 3,
+	VX_LOG_INFO				= 4,
+	VX_LOG_DEBUG			= 5
 } vx_log_level;
 
 typedef enum {
-	VX_PIX_FMT_RGB24 = 0,
-	VX_PIX_FMT_GRAY8 = 1,
-	VX_PIX_FMT_RGB32 = 2,
+	VX_PIX_FMT_RGB24		= 0,
+	VX_PIX_FMT_GRAY8		= 1,
+	VX_PIX_FMT_RGB32		= 2,
 } vx_pix_fmt;
 
 typedef enum {
-	VX_SAMPLE_FMT_S16 = 0,
-	VX_SAMPLE_FMT_FLT = 1
+	VX_SAMPLE_FMT_S16		= 0,
+	VX_SAMPLE_FMT_FLT		= 1
 } vx_sample_fmt;
 
 typedef enum {
-	VX_ERR_FRAME_DEFERRED  = -1,
-	VX_ERR_SUCCESS         = 0,
-	VX_ERR_UNKNOWN         = 1,
-	VX_ERR_ALLOCATE        = 2,
-	VX_ERR_FRAME_RATE      = 3,
-	VX_ERR_OPEN_FILE       = 4,
-	VX_ERR_STREAM_INFO     = 5,
-	VX_ERR_VIDEO_STREAM    = 6,
-	VX_ERR_FIND_CODEC      = 7,
-	VX_ERR_OPEN_CODEC      = 8,
-	VX_ERR_EOF             = 9,
-	VX_ERR_DECODE_VIDEO    = 10,
-	VX_ERR_SCALING         = 11,
-	VX_ERR_PIXEL_ASPECT    = 12,
-	VX_ERR_DECODE_AUDIO    = 13,
-	VX_ERR_NO_AUDIO        = 14,
-	VX_ERR_RESAMPLE_AUDIO  = 15,
-	VX_ERR_FILE_NOT_FOUND  = 16,
-	VX_ERR_INIT_FILTER     = 17,
+	VX_ERR_SUCCESS			= 0,
+	VX_ERR_UNKNOWN			= 1,
+	VX_ERR_ALLOCATE			= 2,
+	VX_ERR_FRAME_RATE		= 3,
+	VX_ERR_OPEN_FILE		= 4,
+	VX_ERR_STREAM_INFO		= 5,
+	VX_ERR_VIDEO_STREAM		= 6,
+	VX_ERR_FIND_CODEC		= 7,
+	VX_ERR_OPEN_CODEC		= 8,
+	VX_ERR_EOF				= 9,
+	VX_ERR_DECODE_VIDEO		= 10,
+	VX_ERR_SCALING			= 11,
+	VX_ERR_PIXEL_ASPECT		= 12,
+	VX_ERR_DECODE_AUDIO		= 13,
+	VX_ERR_NO_AUDIO			= 14,
+	VX_ERR_RESAMPLE_AUDIO	= 15,
+	VX_ERR_FILE_NOT_FOUND	= 16,
+	VX_ERR_INIT_FILTER		= 17,
 } vx_error;
 
 typedef enum {
-	VX_FF_KEYFRAME			= 1 << 0,
-	VX_FF_BYTE_POS_GUESSED	= 1 << 1,
-	VX_FF_HAS_PTS			= 1 << 2,
-	VX_FF_DEFERRED			= 1 << 3
+	VX_FF_HAS_IMAGE			= 1 << 0,
+	VX_FF_HAS_AUDIO			= 1 << 1,
+	VX_FF_KEYFRAME			= 1 << 2,
+	VX_FF_BYTE_POS_GUESSED	= 1 << 3,
+	VX_FF_HAS_PTS			= 1 << 4,
+	VX_FF_DEFERRED			= 1 << 5
 } vx_frame_flag;
 
 typedef enum {
-	VX_HW_ACCEL_ALL  = 1 << 0,
-	VX_HW_ACCEL_720  = 1 << 1,
-	VX_HW_ACCEL_1080 = 1 << 2,
-	VX_HW_ACCEL_1440 = 1 << 3,
-	VX_HW_ACCEL_2160 = 1 << 4,
-	VX_HW_ACCEL_HEVC = 1 << 5,
-	VX_HW_ACCEL_H264 = 1 << 6
+	VX_HW_ACCEL_ALL			= 1 << 0,
+	VX_HW_ACCEL_720			= 1 << 1,
+	VX_HW_ACCEL_1080		= 1 << 2,
+	VX_HW_ACCEL_1440		= 1 << 3,
+	VX_HW_ACCEL_2160		= 1 << 4,
+	VX_HW_ACCEL_HEVC		= 1 << 5,
+	VX_HW_ACCEL_H264		= 1 << 6
 } vx_hwaccel_flag;
 
-typedef void (*vx_audio_callback)(const void* samples, int num_samples, double ts, void* user_data);
 typedef void (*vx_log_callback)(const char* message, int level);
 
 VX_DECLSPEC void VX_CDECL vx_log_set_cb(vx_log_callback cb);
@@ -91,8 +92,7 @@ VX_DECLSPEC int VX_CDECL vx_get_audio_present(const vx_video* video);
 VX_DECLSPEC int VX_CDECL vx_get_audio_sample_rate(const vx_video* video);
 VX_DECLSPEC int VX_CDECL vx_get_audio_channels(const vx_video* video);
 
-VX_DECLSPEC vx_error VX_CDECL vx_set_audio_params(vx_video* me, int sample_rate, int channels, vx_sample_fmt format, vx_audio_callback cb, void* user_data);
-VX_DECLSPEC vx_error VX_CDECL vx_set_audio_max_samples_per_frame(vx_video* me, int max_samples);
+VX_DECLSPEC vx_error VX_CDECL vx_set_audio_params(vx_video* me, int sample_rate, int channels, vx_sample_fmt format);
 
 VX_DECLSPEC long long VX_CDECL vx_get_file_position(const vx_video* video);
 VX_DECLSPEC long long VX_CDECL vx_get_file_size(const vx_video* video);


### PR DESCRIPTION
Audio handling is now simplified, audio frames are now handled through the existing video frame queue. Audio data was previously sent out via a callback, but is now sent as audio frames.

Audio data is only processed as required, in a similar way to video frames. This allows use of a filter pipeline with audio frames, which is currently implemented to provide audio stats per frame.