### PR TITLE
Fix frame queue memory leak

### DIFF
--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1114,13 +1114,17 @@ vx_scene_info vx_frame_get_scene_info(const vx_frame* frame)
 	return frame->scene_info;
 }
 
-static vx_error vx_decode_frame(vx_video* me, AVPacket* packet, static AVFrame* out_frame_buffer[FRAME_QUEUE_SIZE], int* out_frames_count)
+static vx_error vx_decode_frame(vx_video* me, AVPacket* packet, static AVFrame* out_frame_buffer[FRAME_QUEUE_SIZE], int* out_frame_count)
 {
 	vx_error ret = VX_ERR_UNKNOWN;
 	AVCodecContext* codec_ctx = NULL;
 	AVFrame* frame = NULL;
 	int frame_count = 0;
-	*out_frames_count = 0;
+	*out_frame_count = 0;
+
+	// Clear the packet in case it is being reused
+	if (packet && packet->data)
+		av_packet_unref(packet);
 
 	// Get a packet, which will usually be a single video frame, or several complete audio frames
 	vx_read_frame(me->fmt_ctx, packet, me->video_stream);
@@ -1182,12 +1186,13 @@ static vx_error vx_decode_frame(vx_video* me, AVPacket* packet, static AVFrame* 
 			}
 			else {
 				// Dump the frame and the rest of the packet data to prevent buffer overrun
+				av_log(NULL, AV_LOG_WARNING, "Unable to return all frames, temporary frame buffer full. Dropping excess frames\n");
 				break;
 			}
 		}
 	}
 
-	*out_frames_count = frame_count;
+	*out_frame_count = frame_count;
 	ret = VX_ERR_SUCCESS;
 
 cleanup:
@@ -1393,7 +1398,7 @@ vx_error vx_queue_frames(vx_video* me)
 {
 	vx_error ret = VX_ERR_SUCCESS;
 	AVPacket* packet = NULL;
-	static AVFrame* frame_buffer[50] = { NULL };
+	static AVFrame* frame_buffer[FRAME_QUEUE_SIZE] = { NULL };
 	int frame_idx = 0;
 	int frame_count = 0;
 
@@ -1428,14 +1433,14 @@ vx_error vx_queue_frames(vx_video* me)
 		}
 	}
 
-	return ret;
-
 cleanup:
-	for (int i = frame_idx; i < frame_count; i++) {
-		AVFrame* frame = frame_buffer[i];
-		if (frame) {
-			av_frame_unref(frame);
-			av_frame_free(&frame);
+	if (ret != VX_ERR_SUCCESS) {
+		for (int i = frame_idx; i < frame_count; i++) {
+			AVFrame* frame = frame_buffer[i];
+			if (frame) {
+				av_frame_unref(frame);
+				av_frame_free(&frame);
+			}
 		}
 	}
 

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1385,7 +1385,7 @@ static vx_error vx_frame_process_audio(vx_video* video, AVFrame* av_frame, vx_fr
 		return VX_ERR_RESAMPLE_AUDIO;
 	}
 
-	frame->audio_sample_count = dst_sample_count * out_params.channels;
+	frame->audio_sample_count = dst_sample_count;
 
 	return VX_ERR_SUCCESS;
 }


### PR DESCRIPTION
- Clear the temporary frame queue when exiting due to error
- Clear the packet (that is repeatedly reused) before refilling