### PR TITLE
Handle variable audio params

### DIFF
--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1014,7 +1014,7 @@ static int vx_frame_init_audio_buffer(
 
 	// The maximum number of samples per frame, each frame will usually contain far fewer than this
 	int frame_buffer_size = !frame_size || frame_size <= 0
-		? in_params.sample_rate * 4 // Four seconds of buffer
+		? in_params.sample_rate * 2 // Two seconds of buffer
 		: frame_size;
 
 	// The number of samples required per channel
@@ -1419,7 +1419,8 @@ static vx_error vx_frame_process_audio(vx_video* video, AVFrame* av_frame, vx_fr
 
 		// Reinitialize resampler if audio format changes mid stream
 		int frame_samples = vx_frame_init_audio_buffer(frame, params, video->options.audio_params, NULL);
-		if (frame_samples <= 0 || frame_samples < av_frame->nb_samples)
+		// Sanity check to make sure the frame audio buffer can handle the expected number of samples
+		if (frame_samples <= 0 || frame_samples < dst_sample_count)
 			return VX_ERR_RESAMPLE_AUDIO;
 		if (vx_init_audio_resampler(video, params, out_params) != VX_ERR_SUCCESS) {
 			av_log(NULL, AV_LOG_ERROR, "Unable to reinitialize audio resampler after format change.\n");

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -747,17 +747,16 @@ vx_error vx_open(vx_video** video, const char* filename, const vx_video_options 
 			goto cleanup;
 	}
 
-	if (me->audio_codec_ctx) {
+	if (me->audio_codec_ctx && me->options.audio_params.channels > 0) {
 		struct av_audio_params params = {
 			.channel_layout = me->audio_codec_ctx->ch_layout,
 			.sample_format = me->audio_codec_ctx->sample_fmt,
 			.sample_rate = me->audio_codec_ctx->sample_rate,
 			.time_base = me->audio_codec_ctx->time_base
 		};
-		if (me->options.audio_params.channels > 0) {
-			if ((error = vx_init_audio_resampler(me, params, me->options.audio_params)) != VX_ERR_SUCCESS) {
-				goto cleanup;
-			}
+
+		if ((error = vx_init_audio_resampler(me, params, me->options.audio_params)) != VX_ERR_SUCCESS) {
+			goto cleanup;
 		}
 
 		if ((error = vx_init_audio_filter_pipeline(me, params)) != VX_ERR_SUCCESS)

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1417,7 +1417,10 @@ static vx_error vx_frame_process_audio(vx_video* video, AVFrame* av_frame, vx_fr
 		int frame_samples = vx_frame_init_audio_buffer(frame, params, video->options.audio_params, NULL);
 		if (frame_samples <= 0 || frame_samples < av_frame->nb_samples)
 			return VX_ERR_RESAMPLE_AUDIO;
-		vx_init_audio_resampler(video, params, out_params);
+		if (vx_init_audio_resampler(video, params, out_params) != VX_ERR_SUCCESS) {
+			av_log(NULL, AV_LOG_ERROR, "Unable to reinitialize audio resampler after format change.\n");
+			return VX_ERR_ALLOCATE;
+		}
 	}
 
 	int sample_count = swr_convert(video->swr_ctx, frame->audio_buffer, dst_sample_count, (const uint8_t**)av_frame->data, av_frame->nb_samples);

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -678,7 +678,7 @@ vx_error vx_init_audio_resampler(vx_video* me, const struct av_audio_params in_p
 	return VX_ERR_SUCCESS;
 
 cleanup:
-	if (me->swr_ctx && err != VX_ERR_SUCCESS)
+	if (me->swr_ctx)
 		swr_free(&me->swr_ctx);
 
 	return err;

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1318,6 +1318,7 @@ static vx_error vx_filter_audio_frame(const vx_video* video, AVFrame* av_frame)
 		if (filter_source->outputs[0]->sample_rate != av_frame->sample_rate
 			|| filter_source->outputs[0]->ch_layout.nb_channels != av_frame->ch_layout.nb_channels) {
 			struct av_audio_params params = { av_frame->ch_layout, av_frame->format, av_frame->sample_rate, av_frame->time_base };
+
 			if ((result = vx_init_audio_filter_pipeline(video, params) != VX_ERR_SUCCESS))
 				return result;
 
@@ -1434,7 +1435,7 @@ static vx_error vx_frame_process_audio(vx_video* video, AVFrame* av_frame, vx_fr
 		return VX_ERR_RESAMPLE_AUDIO;
 	}
 
-	frame->audio_sample_count = dst_sample_count * out_params.channels;
+	frame->audio_sample_count = dst_sample_count;
 
 	return VX_ERR_SUCCESS;
 }

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1191,8 +1191,8 @@ static vx_error vx_decode_frame(vx_video* me, AVPacket* packet, static AVFrame* 
 		goto cleanup;
 	}
 	if (vx_is_packet_error(result)) {
-		char error_message[64] = { 0 };
-		if (av_strerror(result, &error_message, 64) > 0)
+		char error_message[AV_ERROR_MAX_STRING_SIZE] = { 0 };
+		if (av_strerror(result, &error_message, AV_ERROR_MAX_STRING_SIZE) == 0)
 			av_log(NULL, AV_LOG_ERROR, "%s", error_message);
 
 		ret = VX_ERR_DECODE_VIDEO;

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1338,7 +1338,11 @@ static vx_error vx_filter_audio_frame(const vx_video* video, AVFrame* av_frame)
 		// The frame reference is being reused, so the old frame has to be cleaned up first
 		av_frame_unref(av_frame);
 
-		while (ret == 0) {
+		// More than one frame could be returned, depending on the filter graph layout or
+		// how many frames were fed to the buffer source.
+		// Only non-branching graphs are currently used, but this would need updating to handle
+		// multiple frames if more complex graphs were used.
+		while ((ret >= 0 || ret == AVERROR(EAGAIN)) && !av_frame->data[0]) {
 			ret = av_buffersink_get_frame(filter_sink, av_frame);
 
 			if (vx_is_packet_error(ret)) {

--- a/src/libvx.c
+++ b/src/libvx.c
@@ -1193,7 +1193,7 @@ static vx_error vx_decode_frame(vx_video* me, AVPacket* packet, static AVFrame* 
 	if (vx_is_packet_error(result)) {
 		char error_message[AV_ERROR_MAX_STRING_SIZE] = { 0 };
 		if (av_strerror(result, &error_message, AV_ERROR_MAX_STRING_SIZE) == 0)
-			av_log(NULL, AV_LOG_ERROR, "%s", error_message);
+			av_log(NULL, AV_LOG_ERROR, "Unable to decode packet: %s\n", error_message);
 
 		ret = VX_ERR_DECODE_VIDEO;
 		goto cleanup;


### PR DESCRIPTION
The audio filter graph is initialized for a particular sample rate, format etc when the video is opened. This will not be able to handle frames in a different format if the stream suddenly changes. The filter graph must be reinitialized according to the new format.