### PR TITLE
Check frame format when filtering

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -360,8 +360,7 @@ vx_error vx_filter_frame(const vx_video* video, AVFrame* av_frame, const enum AV
 			// Reinitialize the pipeline if the frame size has changed
 			struct av_video_params frame_params = av_video_params_from_frame(av_frame, &video->fmt_ctx->streams[video->video_stream]->time_base);
 
-			if (filter_source->w != av_frame->width || filter_source->h != av_frame->height) {
-
+			if (filter_source->w != av_frame->width || filter_source->h != av_frame->height || filter_source->format != av_frame->format) {
 				params = &frame_params;
 			}
 		}


### PR DESCRIPTION
Add an extra check to verify the frame format before filtering and reinitialize the filtergraph if they don't match.

This solves a problem that can occur when the hardware acceleration context is successfully initialized on opening the video, but then for some reason fails when decoding frames and falls back to a software context.